### PR TITLE
fixed modelspec.title error

### DIFF
--- a/lora-inspector.py
+++ b/lora-inspector.py
@@ -335,7 +335,7 @@ def parse_metadata(metadata):
             f"train images: {items['ss_num_train_images']} {item(items, 'ss_num_reg_images', 'regularization images')}"
         )
 
-        if items["modelspec.title"] != "":
+        if items.get("modelspec.title", "") != "":
             # item(items, "modelspec.implementation", "implementation"),
             # item(items, "modelspec.resolution", "resolution"),
             # item(items, "modelspec.sai_model_spec", "sai"),


### PR DESCRIPTION
There's an error here with the default modelspec.title check on [line 338](https://github.com/rockerBOO/lora-inspector/blob/main/lora-inspector.py#L338) for me.

![image](https://github.com/rockerBOO/lora-inspector/assets/26351130/7efa6368-7c55-429b-9137-e23af218761e)

I made a small fix to that line.